### PR TITLE
Decisión sobre el gestor de dependencias closes #35

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,4 @@ Aquí se especifican las normas y políticas que se deben seguir en nuestro proy
 - Los PR deben de hacer referencia al issue concreto que cierran, usando palabras clave como, por ejemplo: "Closes #1", donde #1 es el número del issue que cierra.
 - Todo el código que se añada nuevo debe de ser coherente con el ya existente.
 
-- Como gestor de dependencias se usará [pip-tools, poetry, uv]
+- Como gestor de dependencias se usará poetry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,5 @@ Aquí se especifican las normas y políticas que se deben seguir en nuestro proy
 - No se abrirán PR que no describan un issue.
 - Los PR deben de hacer referencia al issue concreto que cierran, usando palabras clave como, por ejemplo: "Closes #1", donde #1 es el número del issue que cierra.
 - Todo el código que se añada nuevo debe de ser coherente con el ya existente.
+
+- Como gestor de dependencias se usará [pip-tools, poetry, uv]


### PR DESCRIPTION
## Descripción

En este PR debemos de decidir qué gestor de dependencias usar. Para ello hay que tener en cuenta lo discutido en el Issue #36 .

Como aún no se ha resuelto dicho Issue, propongo tres opciones, ordenados por complejidad (de menos a más):

- pip-tools
  - Usa los ficheros requirements.in para declarar dependencias, y requirements.txt como equivalente a archivo .lock
- Poetry
  - Usa pyproject.toml y poetry.lock
  - Permite la creación de grupos de dependencias para gestionar diferentes tipos de despliegue (dev, test...)
  - Sigue PEP [621, 735](https://python-poetry.org/docs/managing-dependencies/#group-pep735), [508](https://python-poetry.org/docs/dependency-specification/)
  - También ofrece un gestor de entornos virtuales, aunque no fuerza su uso
- uv  
  - usa pyproject.toml  uv.lock
  - Sigue los standards PEP [508, 518, 735 y 621](https://docs.astral.sh/uv/concepts/projects/dependencies/#platform-specific-dependencies)
  - Ofrece (y fuerza) usar su gestor de entornos virtuales
  - Es rápido (hecho en rust), moderno y tiene varias integraciones (por ejmplo, dependencias de git, github actions, imágenes de docker...), tiene integrado un gestor de versiones de python, 

Comparto la web dónde encontré estos gestores y otros: [link](https://nielscautaerts.xyz/python-dependency-management-is-a-dumpster-fire.html)

## Issue relacionado

- Closes #35 

## Checklist
- [x] Mi PR debe estar asociado a un issue.
- [ ] Mi código resuelve el problema descrito en el issue asociado
- [x] Estoy trabajando sobre una rama que no sea main
- [x] Mi código es coherente con el ya existente
