### PR TITLE
Corrección de dudas generales closes #40

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,2 @@
 blank_issues_enabled: false
-contact_links:
-  - name: 💬 Dudas generales
-    url: https://github.com/JJ/bucker.io/issues
-    about: Para preguntas o comentarios fuera del desarrollo.
+

--- a/.github/ISSUE_TEMPLATE/dudas_generales.yml
+++ b/.github/ISSUE_TEMPLATE/dudas_generales.yml
@@ -1,0 +1,13 @@
+name: 💬 Dudas generales
+description: Usa esta plantilla para preguntas o comentarios fuera del desarrollo.
+title: "[General] <Título de la duda>"
+labels: ["question"]
+body:
+  - type: textarea
+    id: descripcion
+    attributes:
+      label: Descripción de la duda
+      description: Describe la duda o comentario que tienes.
+      placeholder: "Tengo una duda sobre qué tecnologías se usan en el proyecto."
+    validations:
+      required: true


### PR DESCRIPTION
## Descripción

Se ha incluido la issue template de dudas generales y eliminado el link de contacto que redirigía a la Issues. De esta manera el usuario no se confundirá a la hora de crear un issue sobre una duda

## Issue relacionado

- Closes #40

## Checklist
- [x] Mi PR debe estar asociado a un issue.
- [x] Mi código resuelve el problema descrito en el issue asociado
- [x] Estoy trabajando sobre una rama que no sea main
- [x] Mi código es coherente con el ya existente
